### PR TITLE
#34 Added 'main' to package.json to fix require in node

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "RegPack",
     "version": "4.0.0",
     "description": "A packer intended for use on minified Javascript code",
+    "main": "regPack.js",
     "homepage": "https://github.com/Siorki/RegPack",
     "dependencies": {
         "minimist": "1.1.0"


### PR DESCRIPTION
Changing the version tag to `4.0.0` allowed me to install RegPack as a package, but it wouldn't allow me to actually `require()` it until I added `regPack.js` as the main file.