### PR TITLE
Fixed base64 html output for non Latin1 chars

### DIFF
--- a/regPack.html
+++ b/regPack.html
@@ -229,7 +229,7 @@ function doRegPack() {
 		document.getElementById("stage"+j+"Message").setAttribute("class", bestCompression==outputLength ? "bestMessage" : "");
 		document.getElementById("stage"+j+"Base64").onclick = function(index) {
 			return function() { 
-				document.getElementById("stage"+index+"Output").value = this.checked ? btoa(outputCode[index]) : outputCode[index];
+				document.getElementById("stage"+index+"Output").value = this.checked ? btoa(unescape(encodeURIComponent(outputCode[index])))  : outputCode[index];
 			};
 		} (j);
 		document.getElementById("stage"+j+"Base64").onclick();	// set the textarea contents, raw or base64


### PR DESCRIPTION
Fixed btoa() error for Unicode chars like "\uD83D\uDD25":
"Uncaught InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range."

quick test inverted function:
b64 = btoa(unescape(encodeURIComponent(outputCode[1])));
decodeURIComponent(escape(atob(b64))) == outputCode[1]; // must be the same as original text