### PR TITLE
Replace for..in with for..of to save 6 bytes

### DIFF
--- a/regPack.js
+++ b/regPack.js
@@ -210,7 +210,7 @@ RegPack.prototype = {
 		}
 
 		c=s.split('"').length<s.split("'").length?(B='"',/"/g):(B="'",/'/g);
-		i=packerData.packedCodeVarName+'='+B+s.replace(c,'\\'+B)+B+';for(i in G='+B+tokens+B+')with('+packerData.packedCodeVarName+'.split(G[i]))'+packerData.packedCodeVarName+'=join(pop('+packerData.wrappedInit+'));'+packerData.environment+packerData.interpreterCall;
+		i=packerData.packedCodeVarName+'='+B+s.replace(c,'\\'+B)+B+';for(i of'+B+tokens+B+')with('+packerData.packedCodeVarName+'.split(i))'+packerData.packedCodeVarName+'=join(pop('+packerData.wrappedInit+'));'+packerData.environment+packerData.interpreterCall;
 		return [this.getByteLength(i), i, details];
 	},
 


### PR DESCRIPTION
This replaces the for..in-loop in the unpacking bootstrapper with a
for..of loop. This shaves 6 bytes off of the total packed output.

The for..of loop is supported by all current major browsers: Chrome
since version 51, Firefox since version 13, Edge since version 12,
Safari since version 7.1, Chrome for Android since version 38 and Safari
Mobile since version 8.